### PR TITLE
Build this from source to have composable nodes

### DIFF
--- a/iron.repos
+++ b/iron.repos
@@ -38,6 +38,10 @@ repositories:
     type: git
     url: https://github.com/ros2/rmw_zenoh
     version: rolling
+  rosbag2_transport:
+    type: git
+    url: https://github.com/ros2/rosbag2.git
+    version: 0.27.0
   tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git


### PR DESCRIPTION
So after this PR: https://github.com/ros2/rosbag2/pull/1419
We can have ros2 bag recording as composable node.

However, since it's a mono-repo, do I need to change the main.yml file now to exclude all other folder of the rosbag2 repo?